### PR TITLE
Upgrade to solr 9

### DIFF
--- a/.docker.env
+++ b/.docker.env
@@ -23,7 +23,7 @@ POSTGRES_PASSWORD=galacto_pass
 POSTGRES_USER=galacto_user
 
 # Solr
-
+SOLR_MODULES=analysis-extras,extraction
 
 # Redis
 REDIS_PASSWORD=galacto_redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - fcrepo:/data:cached
 
   solr:
-    image: solr:8.11
+    image: solr:9.8
     env_file:
       - .docker.env
     command: solr-precreate galacto /opt/solr/server/configsets/hyraxconf

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -45,7 +45,7 @@
     that avoids logging every request
 -->
 
-<schema name="Hydra Demo Index" version="1.5">
+<schema name="Hydra Demo Index" version="1.7">
   <!-- attribute "name" is the name of this schema and is only used for display purposes.
        Applications should change this to reflect the nature of the search collection.
        version="1.5" is Solr's version number for the schema syntax and semantics.  It should

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -28,14 +28,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>5.0.0</luceneMatchVersion>
-
-  <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib" />
-  <lib dir="${solr.install.dir:../../../..}/modules/extraction/lib" regex=".*\.jar" />>
-  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
-  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
-  <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />
+  <luceneMatchVersion>9.10.0</luceneMatchVersion>
 
   <directoryFactory name="DirectoryFactory" 
                     class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}">


### PR DESCRIPTION
Changes in this PR:

- Switch to solr 9.8 docker image in docker-compose
- Set SOLR_MODULES env var and remove library references in solrconfig (required for solr 9.8+)
- Bump solr schema version to 1.7 (default in solr 9.7+)
- Bump luceneMatchVersion to 9.10.0 (default in solr 9.6+)

Note: A total reindex is needed due to the bump in the schema version and luceneMatchVersion.